### PR TITLE
Add example of cross-account roles

### DIFF
--- a/cloudformation/iam/assume-role-example/README.md
+++ b/cloudformation/iam/assume-role-example/README.md
@@ -49,8 +49,7 @@ This example can be used to specifically create the following resources:
     $ wget https://raw.githubusercontent.com/CU-CommunityApps/aws-examples/master/cloudformation/iam/assume-role-example/assume-role.sh
     $ chmod +x assume-role.sh
     ```
-    3. Change the value of the ASSUME_ROLE variable to the ARN of the `shib-dba` role above.
-      * Use nano, or your favorite linux editor to do this.
+    3. Change the value of the ASSUME_ROLE variable to the ARN of the `shib-dba` role above. Use nano, or your favorite linux editor to do this.
     4. Run the script
     ```
     $ ./assume-role.sh

--- a/cloudformation/iam/assume-role-example/README.md
+++ b/cloudformation/iam/assume-role-example/README.md
@@ -1,0 +1,5 @@
+# Example of assuming a role in a different account
+
+This directory contains templates and a shell script that together provide an example of one role assuming a different role in a different AWS account.
+
+A use case for this is an EC2 instance running under a **home instance profile** in a **home AWS account** needing to assume a **target role** in a **target AWS account** so that it can operate within that target account with the privileges granted by the target role.

--- a/cloudformation/iam/assume-role-example/README.md
+++ b/cloudformation/iam/assume-role-example/README.md
@@ -20,45 +20,66 @@ This example can be used to specifically create the following resources:
   * **target AWS account** account number: 999999999999
 
 1. With appropriate privileges (e.g., shib-admin) in the **home AWS account**, create a new  CloudFormation stack using [instance-profile.yaml](instance-profile.yaml) as the template.
-  * When providing parameters to the stack, be sure to replace the account number in the default "RoleToBeAssumed" value with that of your **target AWS account**.
+  * When providing parameters to the stack, be sure to replace the account number in the default "RoleToBeAssumed" value with that of your **target AWS account**. If you plan to use a different **target role name** in the **target AWS account**, then replace `shib-dba` with that role name (created in the next step).
   * Optionally, replace the default role name and instance profile name with ones of your own choosing.
   * This step will create a new role and instance profile in the **home AWS account**.
   * Take note of the ARN of the ExampleRole under the `Resources` tab of the CloudFormation stack. You will need this in the step below. It will look something like `arn:aws:iam::111111111111:role/example-role`, only with your **home AWS account** number and the name of the role, if specified something other than the default in the parameter section of the stack.
 
 1. Now, with appropriate privileges in the **target AWS account**, create a new CloudFormation stack using the [shib-dba-role-with-assume-role.yaml](shib-dba-role-with-assume-role.yaml) template.
   * When providing parameters to the stack, be sure to:
-    * provide a name for the role to be created by the template; use `shib-dba` unless that conflicts with an existing role.
+    * provide a name for the role to be created by the template; use `shib-dba` unless that conflicts with an existing role. This name must match the name you provided in the previous step.
     * provide the appropriate ARN for that was created in the previous step.
   * Note the ARN of the role created by the CloudFormation stack. It will be in the `Resources` tab.
 
 ## How to test your roles -- High level instructions
 
 1. In the **home AWS account**, create an EC2 instance running Amazon Linux. Be sure to:
-  * launch it on any subnet that has outgoing internet connectivity.
+  * launch it on a subnet that has outgoing internet connectivity.
   * specify a key-pair that you have access to, since you will need to ssh into that instance for this test.
   * specify a security group that will allow port 22 access from your workstation.
 
-1. Once the instance has started, ssh to it. E.g., ssh ec2-user@11.22.33.44.
+1. Once the instance has started, ssh to it. E.g., `ssh -i mykey.pem ec2-user@11.22.33.44`.
 
 1. In a shell on the instance:
-  1. Install `jq`
+  1. Install `jq` (https://stedolan.github.io/jq/).
   ```
   $ sudo yum install jq -y
   ```
-  * Create the test script
+  * Create the test script.
   ```
-  $ echo > assume-role.sh
+  $ wget https://raw.githubusercontent.com/CU-CommunityApps/aws-examples/master/cloudformation/iam/assume-role-example/assume-role.sh
   $ chmod +x assume-role.sh
-  $ nano assume-role.sh
   ```
-    * Paste in the contents of [assume-role.sh](assume-role.sh).
-    * Change the ASSUME_ROLE variable value to the ARN of the `shib-dba` role above.
-    * Ctrl-O to save the file.
-    * Ctrl-X to exit nano.
+  * Change the value of the ASSUME_ROLE variable to the ARN of the `shib-dba` role above.
+    * Use nano, or your favorite linux editor to do this.
   * Run the script
   ```
   $ ./assume-role.sh
+  Assume role: arn:aws:iam::999999999999:role/shib-dba
+  Assume role response:
+  {
+      "AssumedRoleUser": {
+          "AssumedRoleId": "AROAJ3L7...RLKR4:mysession",
+          "Arn": "arn:aws:sts::999999999999:assumed-role/shib-dba/mysession"
+      },
+      "Credentials": {
+          "SecretAccessKey": "lXyszzVD...Y+s",
+          "SessionToken": "FQoDYXdzEJH//////////wEaDG5GlfxxxoaM...+GlEWAo8XtpLHLhJsJxDgsoHTsJrhLB9ChXdEgHhB9BAe+yjSwY7LBQ==",
+          "Expiration": "2017-07-10T15:59:18Z",
+          "AccessKeyId": "ASIAJVS...IXXXX"
+      }
+  }
+  Retrieved temp access key  for role arn:aws:iam::999999999999:role/shib-dba. Key will expire at 2017-07-10T15:59:18Z.
+  AWS CLI command: aws rds describe-db-instances --region us-east-1
+  Command output:
+  {
+    "DBInstances": [
+      ...
+    ]
+  }
   ```
+  If the **target AWS account** doesn't have any existing RDS instances, the "Command output" above will be empty.
+  * The test is a success if you don't get any errors when running the `assume-role.sh` script. The IDs and keys in your "Assume role response" will be different than what is shown here.
 
 
 

--- a/cloudformation/iam/assume-role-example/README.md
+++ b/cloudformation/iam/assume-role-example/README.md
@@ -16,70 +16,69 @@ This example can be used to specifically create the following resources:
 ## How to use these files - High level instructions
 
 1. The following instructions assume the following account numbers. You will want to replace with the relevant account numbers for your case.
-  * **home AWS account** account number: 111111111111
-  * **target AWS account** account number: 999999999999
-
-1. With appropriate privileges (e.g., shib-admin) in the **home AWS account**, create a new  CloudFormation stack using [instance-profile.yaml](instance-profile.yaml) as the template.
-  * When providing parameters to the stack, be sure to replace the account number in the default "RoleToBeAssumed" value with that of your **target AWS account**. If you plan to use a different **target role name** in the **target AWS account**, then replace `shib-dba` with that role name (created in the next step).
-  * Optionally, replace the default role name and instance profile name with ones of your own choosing.
-  * This step will create a new role and instance profile in the **home AWS account**.
-  * Take note of the ARN of the ExampleRole under the `Resources` tab of the CloudFormation stack. You will need this in the step below. It will look something like `arn:aws:iam::111111111111:role/example-role`, only with your **home AWS account** number and the name of the role, if specified something other than the default in the parameter section of the stack.
+    * **home AWS account** account number: 111111111111
+    * **target AWS account** account number: 999999999999
+2. With appropriate privileges (e.g., shib-admin) in the **home AWS account**, create a new  CloudFormation stack using [instance-profile.yaml](instance-profile.yaml) as the template.
+    * When providing parameters to the stack, be sure to replace the account number in the default "RoleToBeAssumed" value with that of your **target AWS account**. If you plan to use a different **target role name** in the **target AWS account**, then replace `shib-dba` with that role name (created in the next step).
+    * Optionally, replace the default role name and instance profile name with ones of your own choosing.
+    * This step will create a new role and instance profile in the **home AWS account**.
+    * Take note of the ARN of the ExampleRole under the `Resources` tab of the CloudFormation stack. You will need this in the step below. It will look something like `arn:aws:iam::111111111111:role/example-role`, only with your **home AWS account** number and the name of the role, if specified something other than the default in the parameter section of the stack.
 
 1. Now, with appropriate privileges in the **target AWS account**, create a new CloudFormation stack using the [shib-dba-role-with-assume-role.yaml](shib-dba-role-with-assume-role.yaml) template.
-  * When providing parameters to the stack, be sure to:
-    * provide a name for the role to be created by the template; use `shib-dba` unless that conflicts with an existing role. This name must match the name you provided in the previous step.
-    * provide the appropriate ARN for that was created in the previous step.
-  * Note the ARN of the role created by the CloudFormation stack. It will be in the `Resources` tab.
+    * When providing parameters to the stack, be sure to:
+      * provide a name for the role to be created by the template; use `shib-dba` unless that conflicts with an existing role. This name must match the name you provided in the previous step.
+      * provide the appropriate ARN for that was created in the previous step.
+    * Note the ARN of the role created by the CloudFormation stack. It will be in the `Resources` tab.
 
 ## How to test your roles -- High level instructions
 
 1. In the **home AWS account**, create an EC2 instance running Amazon Linux. Be sure to:
-  * launch it on a subnet that has outgoing internet connectivity.
-  * specify a key-pair that you have access to, since you will need to ssh into that instance for this test.
-  * specify a security group that will allow port 22 access from your workstation.
+    * launch it on a subnet that has outgoing internet connectivity.
+    * specify a key-pair that you have access to, since you will need to ssh into that instance for this test.
+    * specify a security group that will allow port 22 access from your workstation.
 
 1. Once the instance has started, ssh to it. E.g., `ssh -i mykey.pem ec2-user@11.22.33.44`.
 
 1. In a shell on the instance:
-  1. Install `jq` (https://stedolan.github.io/jq/).
-  ```
-  $ sudo yum install jq -y
-  ```
-  * Create the test script.
-  ```
-  $ wget https://raw.githubusercontent.com/CU-CommunityApps/aws-examples/master/cloudformation/iam/assume-role-example/assume-role.sh
-  $ chmod +x assume-role.sh
-  ```
-  * Change the value of the ASSUME_ROLE variable to the ARN of the `shib-dba` role above.
-    * Use nano, or your favorite linux editor to do this.
-  * Run the script
-  ```
-  $ ./assume-role.sh
-  Assume role: arn:aws:iam::999999999999:role/shib-dba
-  Assume role response:
-  {
-      "AssumedRoleUser": {
-          "AssumedRoleId": "AROAJ3L7...RLKR4:mysession",
-          "Arn": "arn:aws:sts::999999999999:assumed-role/shib-dba/mysession"
-      },
-      "Credentials": {
-          "SecretAccessKey": "lXyszzVD...Y+s",
-          "SessionToken": "FQoDYXdzEJH//////////wEaDG5GlfxxxoaM...+GlEWAo8XtpLHLhJsJxDgsoHTsJrhLB9ChXdEgHhB9BAe+yjSwY7LBQ==",
-          "Expiration": "2017-07-10T15:59:18Z",
-          "AccessKeyId": "ASIAJVS...IXXXX"
-      }
-  }
-  Retrieved temp access key  for role arn:aws:iam::999999999999:role/shib-dba. Key will expire at 2017-07-10T15:59:18Z.
-  AWS CLI command: aws rds describe-db-instances --region us-east-1
-  Command output:
-  {
-    "DBInstances": [
-      ...
-    ]
-  }
-  ```
-  If the **target AWS account** doesn't have any existing RDS instances, the "Command output" above will be empty.
-  * The test is a success if you don't get any errors when running the `assume-role.sh` script. The IDs and keys in your "Assume role response" will be different than what is shown here.
+    1. Install `jq` (https://stedolan.github.io/jq/).
+    ```
+    $ sudo yum install jq -y
+    ```
+    2. Create the test script.
+    ```
+    $ wget https://raw.githubusercontent.com/CU-CommunityApps/aws-examples/master/cloudformation/iam/assume-role-example/assume-role.sh
+    $ chmod +x assume-role.sh
+    ```
+    3. Change the value of the ASSUME_ROLE variable to the ARN of the `shib-dba` role above.
+      * Use nano, or your favorite linux editor to do this.
+    4. Run the script
+    ```
+    $ ./assume-role.sh
+    Assume role: arn:aws:iam::999999999999:role/shib-dba
+    Assume role response:
+    {
+        "AssumedRoleUser": {
+            "AssumedRoleId": "AROAJ3L7...RLKR4:mysession",
+            "Arn": "arn:aws:sts::999999999999:assumed-role/shib-dba/mysession"
+        },
+        "Credentials": {
+            "SecretAccessKey": "lXyszzVD...Y+s",
+            "SessionToken": "FQoDYXdzEJH//////////wEaDG5GlfxxxoaM...+GlEWAo8XtpLHLhJsJxDgsoHTsJrhLB9ChXdEgHhB9BAe+yjSwY7LBQ==",
+            "Expiration": "2017-07-10T15:59:18Z",
+            "AccessKeyId": "ASIAJVS...IXXXX"
+        }
+    }
+    Retrieved temp access key  for role arn:aws:iam::999999999999:role/shib-dba. Key will expire at 2017-07-10T15:59:18Z.
+    AWS CLI command: aws rds describe-db-instances --region us-east-1
+    Command output:
+    {
+      "DBInstances": [
+        ...
+      ]
+    }
+    ```
+    * If the **target AWS account** doesn't have any existing RDS instances, the "Command output" above will be empty.
+    * The test is a success if you don't get any errors when running the `assume-role.sh` script. The IDs and keys in your "Assume role response" will be different than what is shown here.
 
 
 

--- a/cloudformation/iam/assume-role-example/README.md
+++ b/cloudformation/iam/assume-role-example/README.md
@@ -3,3 +3,64 @@
 This directory contains templates and a shell script that together provide an example of one role assuming a different role in a different AWS account.
 
 A use case for this is an EC2 instance running under a **home instance profile** in a **home AWS account** needing to assume a **target role** in a **target AWS account** so that it can operate within that target account with the privileges granted by the target role.
+
+This example can be used to specifically create the following resources:
+* In the **home AWS account**
+  * An IAM role `example-role` and instance profile `example-instance-profile` that an EC2 instance in the home AWS account can use as an instance profile. The instance profile specifically names the **target role** in the **target AWS account** that will be assumed.
+* In the **target AWS account**
+  * An IAM role `shib-dba` that includes three key features:
+    * Trust configuration that will allow Cornell users to assume the role in the **target AWS account**, assuming that the corresponding Active Directory group has been configured. See https://confluence.cornell.edu/x/cghqF.
+    * Trust configuration that will allow an EC2 instance running in the **home AWS account** with `example-instance-profile` to assume the role.
+    * The privileges that a DBA might need to support RDS instances in the **target AWS account**. See also [shib-dba-role.yaml](../shib-dba-role.yaml) CloudFormation template.
+
+## How to use these files - High level instructions
+
+1. The following instructions assume the following account numbers. You will want to replace with the relevant account numbers for your case.
+  * **home AWS account** account number: 111111111111
+  * **target AWS account** account number: 999999999999
+
+1. With appropriate privileges (e.g., shib-admin) in the **home AWS account**, create a new  CloudFormation stack using [instance-profile.yaml](instance-profile.yaml) as the template.
+  * When providing parameters to the stack, be sure to replace the account number in the default "RoleToBeAssumed" value with that of your **target AWS account**.
+  * Optionally, replace the default role name and instance profile name with ones of your own choosing.
+  * This step will create a new role and instance profile in the **home AWS account**.
+  * Take note of the ARN of the ExampleRole under the `Resources` tab of the CloudFormation stack. You will need this in the step below. It will look something like `arn:aws:iam::111111111111:role/example-role`, only with your **home AWS account** number and the name of the role, if specified something other than the default in the parameter section of the stack.
+
+1. Now, with appropriate privileges in the **target AWS account**, create a new CloudFormation stack using the [shib-dba-role-with-assume-role.yaml](shib-dba-role-with-assume-role.yaml) template.
+  * When providing parameters to the stack, be sure to:
+    * provide a name for the role to be created by the template; use `shib-dba` unless that conflicts with an existing role.
+    * provide the appropriate ARN for that was created in the previous step.
+  * Note the ARN of the role created by the CloudFormation stack. It will be in the `Resources` tab.
+
+## How to test your roles -- High level instructions
+
+1. In the **home AWS account**, create an EC2 instance running Amazon Linux. Be sure to:
+  * launch it on any subnet that has outgoing internet connectivity.
+  * specify a key-pair that you have access to, since you will need to ssh into that instance for this test.
+  * specify a security group that will allow port 22 access from your workstation.
+
+1. Once the instance has started, ssh to it. E.g., ssh ec2-user@11.22.33.44.
+
+1. In a shell on the instance:
+  1. Install `jq`
+  ```
+  $ sudo yum install jq -y
+  ```
+  * Create the test script
+  ```
+  $ echo > assume-role.sh
+  $ chmod +x assume-role.sh
+  $ nano assume-role.sh
+  ```
+    * Paste in the contents of [assume-role.sh](assume-role.sh).
+    * Change the ASSUME_ROLE variable value to the ARN of the `shib-dba` role above.
+    * Ctrl-O to save the file.
+    * Ctrl-X to exit nano.
+  * Run the script
+  ```
+  $ ./assume-role.sh
+  ```
+
+
+
+
+

--- a/cloudformation/iam/assume-role-example/assume-role.sh
+++ b/cloudformation/iam/assume-role-example/assume-role.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Example scrip that assumes a role in another account.
+
+ASSUME_ROLE="arn:aws:iam::999999999999:role/shib-dba"
+ROLE_SESSION_NAME="mysession"
+TMP_FILE="assume-role-output.tmp"
+DURATION_SECONDS=900
+AWS_REGION="us-east-1"
+
+echo "Assume role: ${ASSUME_ROLE}"
+
+aws sts assume-role --output json --duration-seconds $DURATION_SECONDS --role-arn ${ASSUME_ROLE} --role-session-name ${ROLE_SESSION_NAME} > ${TMP_FILE}
+
+echo "Assume role response:"
+cat ${TMP_FILE}
+
+ACCESS_KEY_ID=$(jq -r ".Credentials.AccessKeyId" < ${TMP_FILE})
+SECRET_ACCESS_KEY=$(jq -r ".Credentials.SecretAccessKey" < ${TMP_FILE})
+SESSION_TOKEN=$(jq -r ".Credentials.SessionToken" < ${TMP_FILE})
+EXPIRATION=$(jq -r ".Credentials.Expiration" < ${TMP_FILE})
+
+echo "Retrieved temp access key ${ACCESS_KEY} for role ${ASSUME_ROLE}. Key will expire at ${EXPIRATION}."
+
+CMD="aws rds describe-db-instances --region us-east-1"
+
+echo "AWS CLI command: $CMD"
+OUTPUT_FILE="run-command-output.tmp"
+AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY} AWS_SESSION_TOKEN=${SESSION_TOKEN} \
+  ${CMD} > ${OUTPUT_FILE}
+
+echo "Command output:"
+cat ${OUTPUT_FILE}

--- a/cloudformation/iam/assume-role-example/instance-profile.yaml
+++ b/cloudformation/iam/assume-role-example/instance-profile.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Create a role (instance profile) that will be allowed to assume a role in a different account. This template should be run in the home account.
+Parameters:
+  RoleToBeAssumed:
+    Type: String
+    Default: arn:aws:iam::999999999999:role/shib-dba
+    Description: The ARN of the target role that you wish to allow to be assumed in another a target account (e.g. 999999999999).
+Resources:
+  ExampleRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: "example-role"
+      Policies:
+        -
+          PolicyName: "privs-to-assume-target-role"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action: "sts:AssumeRole"
+                Resource: !Ref RoleToBeAssumed
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+  ExampleInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Roles:
+        - !Ref ExampleRole
+      InstanceProfileName: example-instance-profile

--- a/cloudformation/iam/assume-role-example/instance-profile.yaml
+++ b/cloudformation/iam/assume-role-example/instance-profile.yaml
@@ -2,15 +2,23 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   Create a role (instance profile) that will be allowed to assume a role in a different account. This template should be run in the home account.
 Parameters:
+  RoleNameToBeCreated:
+    Type: String
+    Default: example-role
+    Description: The name of the role that this CloudFormation Template will create in the home AWS account.
+  InstanceProfileNameToBeCreated:
+    Type: String
+    Default: example-instance-profile
+    Description: The name of the instance profile that this CloudFormation Template will create in the home AWS account. It will be linked to the role being created.
   RoleToBeAssumed:
     Type: String
     Default: arn:aws:iam::999999999999:role/shib-dba
-    Description: The ARN of the target role that you wish to allow to be assumed in another a target account (e.g. 999999999999).
+    Description: The ARN of the target role that you wish to allow to be assumed in a target account.
 Resources:
   ExampleRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: "example-role"
+      RoleName: !Ref RoleNameToBeCreated
       Policies:
         -
           PolicyName: "privs-to-assume-target-role"
@@ -36,4 +44,4 @@ Resources:
     Properties:
       Roles:
         - !Ref ExampleRole
-      InstanceProfileName: example-instance-profile
+      InstanceProfileName: !Ref InstanceProfileNameToBeCreated

--- a/cloudformation/iam/assume-role-example/shib-dba-role-with-assume-role.yaml
+++ b/cloudformation/iam/assume-role-example/shib-dba-role-with-assume-role.yaml
@@ -1,0 +1,83 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Create a role for DBAs that can be assumed with Cornell Shibboleth. See
+  https://confluence.cornell.edu/display/CLOUD/Creating+Custom+Roles+to+use+With+Shibboleth.
+  The role can also be assumed by the role given as parameter, even when that role
+  is from another AWS account.
+Parameters:
+  ArnOfRoleToBeAllowedToAssumeShibDba:
+    Type: String
+    Default: arn:aws:iam::111111111111:role/example-role
+    Description: The ARN of the role that you wish to allow to assume the shib-dba role. This role can be from a different AWS account altogether.
+Resources:
+  DBARole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: "shib-dba"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+                Federated: !Join [ "", [ "arn:aws:iam::", !Ref "AWS::AccountId", ":saml-provider/cornell_idp" ] ]
+            Action: "sts:AssumeRoleWithSAML"
+            Condition:
+              StringEquals:
+                SAML:aud: "https://signin.aws.amazon.com/saml"
+          -
+            Effect: "Allow"
+            Principal:
+                AWS: !Ref ArnOfRoleToBeAllowedToAssumeShibDba
+            Action: "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonRDSFullAccess
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
+      Policies:
+        -
+          PolicyName: "SecurityGroupFullControl"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - "ec2:CreateSecurityGroup"
+                  - "ec2:DescribeSecurityGroup"
+                  - "ec2:DescribeVpcs"
+                Resource: "*"
+              -
+                Effect: "Allow"
+                Action:
+                  - "ec2:AuthorizeSecurityGroupEgress"
+                  - "ec2:AuthorizeSecurityGroupIngress"
+                  - "ec2:DeleteSecurityGroup"
+                  - "ec2:RevokeSecurityGroupEgress"
+                  - "ec2:RevokeSecurityGroupIngress"
+                Resource: !Join [ "", [ "arn:aws:ec2:us-east-1:", !Ref "AWS::AccountId", ":*" ] ]
+        -
+          PolicyName: "TagsFullControl"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - "ec2:CreateTags"
+                  - "ec2:DeleteTags"
+                  - "ec2:DecribeTags"
+                Resource: !Join [ "", [ "arn:aws:ec2:us-east-1:", !Ref "AWS::AccountId", ":*" ] ]
+        -
+          PolicyName: "CloudwatchAlarmsFullControl"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - "cloudwatch:DisableAlarmActions"
+                  - "cloudwatch:EnableAlarmActions"
+                  - "cloudwatch:PutMetricAlarm"
+                  - "cloudwatch:SetAlarmState"
+                  - "cloudwatch:DeleteAlarms"
+                Resource: "*"

--- a/cloudformation/iam/assume-role-example/shib-dba-role-with-assume-role.yaml
+++ b/cloudformation/iam/assume-role-example/shib-dba-role-with-assume-role.yaml
@@ -5,15 +5,19 @@ Description: >
   The role can also be assumed by the role given as parameter, even when that role
   is from another AWS account.
 Parameters:
+  NameOfRoleToBeCreated:
+    Type: String
+    Default: shib-dba
+    Description: The name of the role to be created by this template. To work with Cornell Shibboleth, it must be of the form "shib-XXXX" where XXXX consists of only numbers and letters.
   ArnOfRoleToBeAllowedToAssumeShibDba:
     Type: String
     Default: arn:aws:iam::111111111111:role/example-role
-    Description: The ARN of the role that you wish to allow to assume the shib-dba role. This role can be from a different AWS account altogether.
+    Description: The ARN of the role that you wish to allow to assume the role created by this template. This role can be from a different AWS account altogether.
 Resources:
   DBARole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: "shib-dba"
+      RoleName: !Ref NameOfRoleToBeCreated
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
Fully detailed example of setting shib-dba role in a target account and configuring a role in a home account that can assume that role.