### PR TITLE
Removing additional parameters for restore

### DIFF
--- a/lambda/dynamodb-backup/restore.js
+++ b/lambda/dynamodb-backup/restore.js
@@ -61,6 +61,8 @@ async.waterfall([
     delete params["TableArn"];
     delete params["TableStatus"];
     delete params["ProvisionedThroughput"]["NumberOfDecreasesToday"];
+    delete params["ProvisionedThroughput"]["LastIncreaseDateTime"];
+    delete params["ProvisionedThroughput"]["LastDecreaseDateTime"];
 
 
 	if(params.hasOwnProperty("GlobalSecondaryIndexes")) {


### PR DESCRIPTION
The parameters LastIncreaseDateTime and LastDecreaseDateTime in ProvisionedThroughput should not be used in the restore for the newly created table.